### PR TITLE
Android 11 permission check fix

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -246,6 +246,12 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                         return new String[]{ Manifest.permission.CAMERA, Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO };
                 }
             }
+        } else if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            if (storageOnly) {
+                return new String[]{Manifest.permission.READ_EXTERNAL_STORAGE};
+            } else {
+                return new String[]{Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE};
+            }
         } else {
             if (storageOnly) {
                 return new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE};


### PR DESCRIPTION

### Platforms affected
Android 11


### Motivation and Context
On Android 11, plugin always returns error 20 (PERMISSION_DENIED_ERROR) on camera open.

### Description
changed "getPermission" to return only READ_EXTERNAL_STORAGE o CAMERA + READ_EXTERNAL_STORAGE when called on Android 11 and above (but below android 13). 
This was necessary to avoid ERROR 20 whenc hecking permission status on camera opening (permission for WRITE_EXTERNAL_STORAGE always returned -1)

Maybe this should be merged with the rest of the commit on the main cordova plugin project.


### Testing
Tested on Android 11 Emulator



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
